### PR TITLE
Utilized pop for meta keys cleanup

### DIFF
--- a/src/custom_layers.py
+++ b/src/custom_layers.py
@@ -87,7 +87,7 @@ class HQQLinearTritonSavable(HQQLinear):
 
         #Cleanup
         for key in del_keys:
-            del meta[key]
+            meta.pop(key, None)
 
         return output
 


### PR DESCRIPTION
Instead of manually iterating through each key in del_keys to delete them from the meta dictionary, use the pop() method to remove these keys if they exist

The pop() method removes the key if it exists and does nothing if the key is not found